### PR TITLE
Add test harness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ all: test build container
 
 .PHONY: test
 test:
+	go test -v ./harness
 	go test -v ./stellar-wallet-server_test.go
 	go test -v ./account
 	go test -v ./api

--- a/account/create.go
+++ b/account/create.go
@@ -13,6 +13,10 @@ func createKeyPair() (string, string, error) {
 	return pair.Address(), pair.Seed(), err
 }
 
+func CreateKeyPair() (string, string, error) {
+	return createKeyPair()
+}
+
 func CreateAccount(c *gin.Context) {
 	address, seed, err := createKeyPair()
 	if err != nil {

--- a/account/query_test.go
+++ b/account/query_test.go
@@ -1,7 +1,11 @@
 package account
 
 import (
+	"log"
 	"testing"
+
+	"github.com/darthlukan/stellar-wallet-server/harness"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestGetAccount(t *testing.T) {
@@ -13,4 +17,26 @@ func TestGetAccount(t *testing.T) {
 	if err == nil {
 		t.Errorf("getAccount('TEST'):err = %v; want 'horizon error: \"Bad Request\" - check horizon.Error.Problem for more information'", err)
 	}
+
+	taccount, err := harness.CreateTestAccount()
+	if err != nil {
+		t.Fatalf("harness.CreateTestAccount():err = %v; want nil", err)
+	}
+
+	// We don't care about the returned JSON in this case,
+	// if err is nil we're funded and can operate
+	_, er := harness.FundTestAccount(&taccount)
+	if er != nil {
+		t.Fatalf("harness.FundTestAccount(&taccount):err = %v; want nil", er)
+	}
+
+	rtAccount, err := getAccount(taccount.Address)
+	if err != nil {
+		t.Fatalf("getAccount(taccount.Address):err = %v; want nil", err)
+	}
+
+	log.Printf("rtAccount is %T, rtAccount = %v", rtAccount, rtAccount)
+
+	assert.Greater(t, len(rtAccount.Balances), 0, "We should have at least one balance")
+	assert.NotEmpty(t, rtAccount.AccountID, "AccountID should not be empty string")
 }

--- a/harness/main.go
+++ b/harness/main.go
@@ -23,26 +23,26 @@ func CreateTestAccount() (TestAccount, error) {
 		log.Printf("account.CreateKeyPair():err = %v; want nil", err)
 	}
 
-	account := TestAccount{
+	taccount := TestAccount{
 		Address: address,
 		Seed:    seed,
 	}
-	return TestAccount, err
+	return taccount, err
 }
 
-func FundTestAccount(account *TestAccount) error {
+func FundTestAccount(account *TestAccount) (string, error) {
 	address := account.Address
 	resp, err := http.Get(friendBotUrl + address)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	defer resp.Body.Close()
 	body, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	log.Printf("body is %T; body = %v", body, string(body))
-	return nil
+	accountJson := string(body)
+	return accountJson, nil
 }

--- a/harness/main.go
+++ b/harness/main.go
@@ -1,0 +1,48 @@
+package harness
+
+import (
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/darthlukan/stellar-wallet-server/account"
+)
+
+const (
+	friendBotUrl string = "https://friendbot.stellar.org/?addr="
+)
+
+type TestAccount struct {
+	Address string
+	Seed    string
+}
+
+func CreateTestAccount() (TestAccount, error) {
+	address, seed, err := account.CreateKeyPair()
+	if err != nil {
+		log.Printf("account.CreateKeyPair():err = %v; want nil", err)
+	}
+
+	account := TestAccount{
+		Address: address,
+		Seed:    seed,
+	}
+	return TestAccount, err
+}
+
+func FundTestAccount(account *TestAccount) error {
+	address := account.Address
+	resp, err := http.Get(friendBotUrl + address)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	log.Printf("body is %T; body = %v", body, string(body))
+	return nil
+}

--- a/harness/main.go
+++ b/harness/main.go
@@ -5,7 +5,7 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/darthlukan/stellar-wallet-server/account"
+	"github.com/stellar/go/keypair"
 )
 
 const (
@@ -17,8 +17,13 @@ type TestAccount struct {
 	Seed    string
 }
 
+func createKeyPair() (string, string, error) {
+	pair, err := keypair.Random()
+	return pair.Address(), pair.Seed(), err
+}
+
 func CreateTestAccount() (TestAccount, error) {
-	address, seed, err := account.CreateKeyPair()
+	address, seed, err := createKeyPair()
 	if err != nil {
 		log.Printf("account.CreateKeyPair():err = %v; want nil", err)
 	}

--- a/harness/main_test.go
+++ b/harness/main_test.go
@@ -1,0 +1,38 @@
+package harness
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCreateTestAccount(t *testing.T) {
+	taccount, err := CreateTestAccount()
+	if err != nil {
+		t.Fatalf("CreateTestAccount():err = %v; want nil", err)
+	}
+	assert.Greater(t, len(taccount.Address), 0, "should be greater than zero")
+	assert.Greater(t, len(taccount.Seed), 0, "should be reater than zero")
+}
+
+func TestFundTestAccount(t *testing.T) {
+	taccount, err := CreateTestAccount()
+	if err != nil {
+		t.Fatalf("CreateTestAccount():err = %v; want nil", err)
+	}
+
+	rawAccountJson, err := FundTestAccount(&taccount)
+	if err != nil {
+		t.Fatalf("FundTestAccount(&taccount):err = %v; want nil", err)
+	}
+
+	var accountJson map[string]interface{}
+	er := json.Unmarshal([]byte(rawAccountJson), &accountJson)
+	if er != nil {
+		t.Fatalf("json.Unmarshal:er = %v; want nil", er)
+	}
+
+	assert.True(t, accountJson["successful"].(bool), "successful should equal true")
+	assert.Contains(t, accountJson["max_fee"].(string), "10", "max_fee should be greater than 10 XLM")
+}


### PR DESCRIPTION
This PR implements a (test) harness package which is used to provide test accounts and other setup necessary before useful tests can be executed. It is meant to be imported by `*_test.go` files.

Implements #14 